### PR TITLE
Fix unused preconnect and delay GTM past load to help LCP/SI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     
     <!-- Preconnect to origins used for streamer avatars and live status -->
-    <link rel="preconnect" href="https://static-cdn.jtvnw.net" crossorigin />
+    <link rel="preconnect" href="https://static-cdn.jtvnw.net" />
     <link rel="preconnect" href="https://raw.githubusercontent.com" crossorigin />
 
     <!-- Favicon and Icons -->

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -19,12 +19,23 @@ if (ENABLE_ANALYTICS) {
     console.log(`🔍 Google Analytics loaded: ${GA_TRACKING_ID}`);
   };
 
-  // Defer GTM until the browser is idle so it doesn't compete with
-  // initial render/main-thread work on first load.
-  if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(loadGtag, { timeout: 4000 });
+  // Defer GTM until after the page has fully loaded, then wait for an
+  // idle moment. A bare requestIdleCallback with a multi-second timeout
+  // can get force-fired mid-render under CPU/network throttling (the
+  // browser never reports idle in time), landing right on top of LCP -
+  // waiting for `load` first guarantees GTM never competes with it.
+  const scheduleLoadGtag = () => {
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(loadGtag, { timeout: 2000 });
+    } else {
+      window.setTimeout(loadGtag, 1000);
+    }
+  };
+
+  if (document.readyState === 'complete') {
+    scheduleLoadGtag();
   } else {
-    window.setTimeout(loadGtag, 2000);
+    window.addEventListener('load', scheduleLoadGtag, { once: true });
   }
 } else {
   console.log('🚫 Google Analytics disabled via environment variables');


### PR DESCRIPTION
## Summary
Follow-up to the previous PageSpeed fixes. Latest report (Performance 86, Accessibility/Agentic browsing both maxed) surfaced two things:

- **`static-cdn.jtvnw.net` preconnect flagged as unused** ("Check that the crossorigin attribute is used properly") — the avatar `<img>` tags are plain, non-CORS requests, but the preconnect hint I'd added earlier included `crossorigin`, so the browser couldn't reuse that connection for the actual image fetches and opened a second one instead. Dropped `crossorigin` from that hint. `raw.githubusercontent.com` keeps it since that origin is hit via a real CORS `fetch()`.
- **LCP stuck at 4.0s** despite FCP/TBT/SI all improving. The LCP breakdown showed ~2.3s of unexplained "element render delay" for the header text, and the network waterfall showed GTM's script request starting at ~3.5s — suspiciously close to the reported 4.0s LCP. The previous fix deferred GTM via `requestIdleCallback(loadGtag, { timeout: 4000 })`, but under CPU/network throttling the browser may never report idle before the timeout, forcing GTM to fire mid-render right around when LCP is trying to happen. Changed the deferral to wait for the `load` event first, then use a much shorter idle timeout — this removes the possibility of GTM injection colliding with the critical rendering path entirely.

## Caveats
I wasn't able to re-run PageSpeed Insights against the deployed site to confirm the LCP/SI numbers actually move (network access to external tools was unavailable in this session) — these are well-reasoned fixes based on what the report data showed, but worth re-checking PageSpeed after this merges and deploys.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified locally in the dev server (Playwright): app renders correctly, no console errors, filters/cards unaffected
- [ ] Re-run PageSpeed Insights after deploy to confirm LCP/SI improvement


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbakkE8AEJtpierBsvhWo3)_