### PR TITLE
Defer initial live-status fetch to reduce critical-path contention

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,11 +91,24 @@ export default function StreamersDirectory() {
       }
     };
 
-    fetchLiveStatus();
+    // Defer the initial fetch slightly so it doesn't compete with the
+    // JS/CSS bundle for bandwidth during the most contended part of the
+    // initial load. A short timeout (well before typical LCP) keeps the
+    // "Live now" badges from visibly lagging for real users.
+    let idleHandle: number | undefined;
+    let timeoutHandle: number | undefined;
+    if (typeof window.requestIdleCallback === "function") {
+      idleHandle = window.requestIdleCallback(fetchLiveStatus, { timeout: 1500 });
+    } else {
+      timeoutHandle = window.setTimeout(fetchLiveStatus, 500);
+    }
+
     const interval = setInterval(fetchLiveStatus, LIVE_STATUS_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(interval);
+      if (idleHandle !== undefined) window.cancelIdleCallback(idleHandle);
+      if (timeoutHandle !== undefined) window.clearTimeout(timeoutHandle);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Same reasoning as the earlier GTM-deferral fix, applied to the live-status fetch this time.

Both PageSpeed reports consistently showed the `live-status.json` request as the longest link in the "network dependency tree" / critical path chain (619-713ms) - it fires almost immediately on mount, competing with the JS/CSS bundle for bandwidth during the most contended part of the initial load under throttling.

- The initial fetch is now deferred via `requestIdleCallback` with a 1500ms timeout (`setTimeout` fallback for browsers without it)
- Chosen deliberately shorter than the GTM fix's deferral: this is real user-facing data (the "Live now" badges), not invisible analytics, so it shouldn't visibly lag for real users - and 1500ms is comfortably before typical LCP (~4s in the reports), so it can't collide with it the way a longer timeout risked doing for GTM
- The 60s recurring poll interval is unaffected - only the very first fetch is deferred

## Test plan
- [x] `npm run build` succeeds
- [x] Verified locally in the dev server (Playwright): the `live-status.json` request now fires ~1.5s after navigation start (well after the `load` event at ~1.1s), instead of firing synchronously at mount
- [x] No console/page errors
- [ ] Re-run PageSpeed Insights after deploy to confirm the critical-path latency improvement


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbakkE8AEJtpierBsvhWo3)_