### PR TITLE
Render initial card batch, then reveal the rest after first paint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,12 +58,19 @@ const getCountryFlag = (country: string): string => {
 
 const STREAMERS: Streamer[] = streamersData;
 
+// Cards rendered on the very first paint, before the rest are revealed.
+// React commits the header text and the card grid in the same pass, so
+// capping the initial batch keeps the browser from having to lay out and
+// style all ~1,200 DOM nodes of the full grid before it can paint LCP.
+const INITIAL_VISIBLE_COUNT = 8;
+
 export default function StreamersDirectory() {
   const [query, setQuery] = useState("");
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [activeCountries, setActiveCountries] = useState<string[]>([]);
   const [liveHandles, setLiveHandles] = useState<Set<string>>(new Set());
   const [onlyLive, setOnlyLive] = useState(false);
+  const [revealAll, setRevealAll] = useState(false);
 
   // Initialize search from URL parameter
   useEffect(() => {
@@ -71,6 +78,20 @@ export default function StreamersDirectory() {
     const searchParam = urlParams.get('search');
     if (searchParam) {
       setQuery(decodeURIComponent(searchParam));
+    }
+  }, []);
+
+  // Reveal the rest of the grid right after first paint. This only ever
+  // fires once - after that every filter/search change already renders
+  // the full result set immediately.
+  useEffect(() => {
+    const reveal = () => setRevealAll(true);
+    if (typeof window.requestIdleCallback === "function") {
+      const handle = window.requestIdleCallback(reveal, { timeout: 300 });
+      return () => window.cancelIdleCallback(handle);
+    } else {
+      const handle = window.setTimeout(reveal, 0);
+      return () => window.clearTimeout(handle);
     }
   }, []);
 
@@ -140,6 +161,8 @@ export default function StreamersDirectory() {
       return matchesQuery && matchesTags && matchesCountries && matchesLive;
     });
   }, [query, activeTags, activeCountries, onlyLive, liveHandles, shuffledStreamers]);
+
+  const visibleStreamers = revealAll ? filtered : filtered.slice(0, INITIAL_VISIBLE_COUNT);
 
   const toggleTag = (tag: string) => {
     setActiveTags((prev) =>
@@ -282,7 +305,7 @@ export default function StreamersDirectory() {
 
           <main className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" role="main" aria-label="Global Twitch streamers directory">
             <h2 className="sr-only">Streamer directory</h2>
-            {filtered.map((s, idx) => (
+            {visibleStreamers.map((s, idx) => (
               <article
                 key={s.handle}
                 className="opacity-0 animate-fadeIn"


### PR DESCRIPTION
## Summary
Targets the one number that hasn't moved across any previous fix: the LCP breakdown's "element render delay" (~2,290-2,310ms in every report so far, including after the preconnect/GTM-timing/avatar-hosting fixes).

The DOM-size diagnostic in the latest report explains why - **1,199 total DOM elements**, all committed and painted in a single React pass. The LCP element is the header's description text, but React doesn't paint it separately from the 36-card grid below it (~33 elements/card): the browser has to lay out and style the *entire* tree, cards included, before it can paint anything, even though the cards aren't the LCP element themselves.

- Caps the initial render to 8 cards (`INITIAL_VISIBLE_COUNT`)
- A new `revealAll` flag flips to `true` via `requestIdleCallback` (short/no-forced-timeout, `setTimeout` fallback) right after first paint, rendering the rest
- `revealAll` only ever goes `true` once - it never resets, so any search or filter interaction after that first reveal always renders the full matching result set immediately, never a capped one
- Footer's "Found: N" count already read from the full `filtered` array, not the visible slice, so it was correct without changes

## Test plan
- [x] `npm run build` succeeds
- [x] Verified in the dev server (Playwright): exactly 8 `<article>` cards exist immediately after `DOMContentLoaded`, all 36 present ~600ms later
- [x] Verified filtering isn't affected by the cap: searching "faker" correctly narrows to exactly 1 card; searching "variety" (which matches more than 8) returns all 27 matches, not capped at 8
- [x] Verified this holds even when searching immediately after a fresh page load (before the reveal has necessarily settled)
- [x] No console/page errors
- [ ] Re-run PageSpeed Insights after deploy to confirm the LCP render-delay improvement


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbakkE8AEJtpierBsvhWo3)_