### PR TITLE
Inline built CSS to remove it from the render-blocking path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,38 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// Inlines the built CSS directly into index.html instead of a separate
+// <link rel="stylesheet">, removing it as a render-blocking network
+// request from the critical path. Worth it specifically for this site:
+// the whole stylesheet is a single small (~5.5 KB gzipped) bundle, it's a
+// single-page app with no other pages to share a cached CSS file with,
+// and GitHub Pages already caps all caching at 10 minutes regardless -
+// so there's no meaningful separate-caching benefit being given up.
+function inlineCss(): Plugin {
+  let cssContent = ''
+  return {
+    name: 'inline-css',
+    generateBundle(_options, bundle) {
+      for (const fileName of Object.keys(bundle)) {
+        const chunk = bundle[fileName]
+        if (fileName.endsWith('.css') && chunk.type === 'asset') {
+          cssContent += chunk.source
+          delete bundle[fileName]
+        }
+      }
+    },
+    transformIndexHtml(html) {
+      return html
+        .replace(/<link[^>]*rel="stylesheet"[^>]*>\n?/, '')
+        .replace('</head>', `    <style>${cssContent}</style>\n  </head>`)
+    },
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), inlineCss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
Fixes the "Render-blocking requests" opportunity (~310ms) that's shown up unchanged in every PageSpeed report so far.

Adds a small local Vite plugin (`inlineCss` in `vite.config.ts`, no new dependency) that:
- Captures the emitted CSS asset's content in `generateBundle`, then deletes it from the output bundle so it's never shipped as a separate file
- Replaces the `<link rel="stylesheet">` tag with an inline `<style>` tag containing that content, via `transformIndexHtml`

This removes the CSS network round-trip from the critical rendering path entirely - the browser no longer has to wait on a second request before it can paint.

## Why this fits this site specifically
Inlining CSS is usually a trade-off (you give up the browser being able to cache CSS separately from HTML across page loads), but none of the usual downsides really apply here:
- The whole stylesheet is one small Tailwind bundle (~5.5 KB gzipped) - not a large file where the extra bytes-per-page-load would add up
- It's a single-page app, so there's no second page that could reuse a separately-cached CSS file anyway
- GitHub Pages already caps `Cache-Control` at a flat 10 minutes on everything, so the "long-term caching" benefit of an external file that you'd normally be giving up doesn't actually exist on this host today

## Test plan
- [x] `npm run build` succeeds; confirmed no `.css` file is emitted in `dist/assets/` anymore and `index.html` contains an inline `<style>` tag with the full Tailwind output
- [x] Verified against the actual production build (`vite preview`, not the dev server) with Playwright: zero `.css` network requests, no console/page errors
- [x] Visually verified styling is unchanged at both desktop (1280px) and mobile (412px) viewports
- [ ] Re-run PageSpeed Insights after deploy to confirm the render-blocking opportunity is gone


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbakkE8AEJtpierBsvhWo3)_